### PR TITLE
Ignore .git directory on building an addon

### DIFF
--- a/src/addon/AddonBuilder.ts
+++ b/src/addon/AddonBuilder.ts
@@ -8,7 +8,7 @@ const walk = (dir: string, callback: (p: string) => void): void => {
   fs.readdirSync(dir).forEach((f) => {
     let dirPath = path.join(dir, f);
     if (fs.statSync(dirPath).isDirectory()) {
-      if (f === 'node_modules') {
+      if (f === 'node_modules' || f === '.git') {
         return
       }
       return walk(dirPath, callback);


### PR DESCRIPTION
When lanthan build an addon from the file system, `.git` directory is clearly not needed.  The `.git` directory can increase in size, from few tens to hundreds of megabytes. The build script ignores the directory, and reduce time to build the addon.